### PR TITLE
Add x86_64 support to atomic operations benchmark

### DIFF
--- a/LSE/Makefile
+++ b/LSE/Makefile
@@ -1,26 +1,60 @@
 CC = clang
-CFLAGS = -O2 -Wall -march=armv8-a+lse
+
+# Architecture-specific flags
+ARCH ?=
+ARM64_CFLAGS = -O2 -Wall -march=armv8-a+lse
+X86_CFLAGS = -O2 -Wall -march=x86-64
+
+# Select architecture flags based on ARCH variable
+ifeq ($(ARCH),arm64)
+    CFLAGS = $(ARM64_CFLAGS)
+else ifeq ($(ARCH),x86)
+    CFLAGS = $(X86_CFLAGS)
+else
+    CFLAGS =
+endif
+
+# Default target - require architecture selection
+default:
+	@echo "Please specify architecture: make ARCH=x86 or make ARCH=arm64"
+	@echo "Or use convenience targets: make x86 or make arm64"
+	@exit 1
+
+# Convenience targets
+x86:
+	$(MAKE) ARCH=x86 all
+
+arm64:
+	$(MAKE) ARCH=arm64 all
 
 percpu_bench: percpu_bench.c percpu_bench_lib.c percpu_bench_lib.h
+	@if [ -z "$(ARCH)" ]; then echo "Error: ARCH not set. Use make ARCH=x86 or make ARCH=arm64"; exit 1; fi
 	$(CC) $(CFLAGS) -pthread percpu_bench.c percpu_bench_lib.c -o percpu_bench
 
 percpu_bench_debug: percpu_bench.c percpu_bench_lib.c percpu_bench_lib.h
-	$(CC) -pthread -g -march=armv8-a+lse percpu_bench.c percpu_bench_lib.c -o percpu_bench_debug
+	@if [ -z "$(ARCH)" ]; then echo "Error: ARCH not set. Use make ARCH=x86 or make ARCH=arm64"; exit 1; fi
+	$(CC) -pthread -g -Wall $(CFLAGS) percpu_bench.c percpu_bench_lib.c -o percpu_bench_debug
 
 parallel_atomic_bench: parallel_atomic_bench.c
+	@if [ -z "$(ARCH)" ]; then echo "Error: ARCH not set. Use make ARCH=x86 or make ARCH=arm64"; exit 1; fi
 	$(CC) $(CFLAGS) -pthread parallel_atomic_bench.c -o parallel_atomic_bench
 
 parallel_atomic_bench_debug: parallel_atomic_bench.c
-	$(CC) -g -Wall -march=armv8-a+lse -pthread parallel_atomic_bench.c -o parallel_atomic_bench_debug
+	@if [ -z "$(ARCH)" ]; then echo "Error: ARCH not set. Use make ARCH=x86 or make ARCH=arm64"; exit 1; fi
+	$(CC) -g -Wall $(CFLAGS) -pthread parallel_atomic_bench.c -o parallel_atomic_bench_debug
 
 asm: percpu_bench.c percpu_bench_lib.c
+	@if [ -z "$(ARCH)" ]; then echo "Error: ARCH not set. Use make ARCH=x86 or make ARCH=arm64"; exit 1; fi
 	$(CC) $(CFLAGS) -S percpu_bench.c -o percpu_bench.s
 	$(CC) $(CFLAGS) -S percpu_bench_lib.c -o percpu_bench_lib.s
 
 parallel_asm: parallel_atomic_bench.c
+	@if [ -z "$(ARCH)" ]; then echo "Error: ARCH not set. Use make ARCH=x86 or make ARCH=arm64"; exit 1; fi
 	$(CC) $(CFLAGS) -S parallel_atomic_bench.c -o parallel_atomic_bench.s
 
 clean:
 	rm -f percpu_bench percpu_bench.s percpu_bench_lib.s percpu_bench_debug parallel_atomic_bench parallel_atomic_bench.s parallel_atomic_bench_debug
 
 all: percpu_bench percpu_bench_debug parallel_atomic_bench parallel_atomic_bench_debug asm parallel_asm
+
+.PHONY: default x86 arm64 clean all

--- a/LSE/percpu_bench_lib.c
+++ b/LSE/percpu_bench_lib.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Benchmark for ARM64 per-CPU atomic operations - Library implementation
+ * Benchmark for per-CPU atomic operations - Library implementation
+ * Supports both ARM64 and x86_64 architectures
  */
 
 #define _GNU_SOURCE
@@ -85,8 +86,15 @@ static void *contender_main(void *arg_uncast)
 
 	while (atomic_load(&arg->done) == 0) {
 		arg->func(arg->counter, 1);
-		for (long i = 0; i < arg->contention; ++i)
+		for (long i = 0; i < arg->contention; ++i) {
+#if defined(__aarch64__)
 			__asm__ volatile ("nop");
+#elif defined(__x86_64__)
+			__asm__ volatile ("nop");
+#else
+#error "Unsupported architecture"
+#endif
+		}
 	}
 
 	return NULL;


### PR DESCRIPTION
  Extends the ARM64 atomic operations benchmark to support x86_64 architecture using conditional compilation.

  Changes

  Architecture mapping:
  - ARM64 LL/SC → x86 lock cmpxchg loop
  - ARM64 LSE stadd → x86 lock add
  - ARM64 LSE ldadd → x86 lock xadd
  - ARM64 prfm pstl1keep → x86 prefetcht0
  - ARM64 prfm pstl1strm → x86 prefetchnta

  Build system:
  - Added explicit architecture targets: make x86 and make arm64
  - Architecture-specific compiler flags via ARCH variable

  Modified files:
  - Makefile - Multi-architecture build support
  - percpu_bench.c - 5 x86 atomic implementations
  - parallel_atomic_bench.c - 2 x86 atomic implementations
  - percpu_bench_lib.c - Architecture-agnostic nop handling

  Both architectures maintained with #ifdef __aarch64__ / #elif defined(__x86_64__) guards.