### PR TITLE
Use uname -m to determine processor type

### DIFF
--- a/vdso_bench/Makefile
+++ b/vdso_bench/Makefile
@@ -2,9 +2,9 @@ CC      = clang
 CFLAGS  = -Wall -O2 -g -W
 ALL_CFLAGS = $(CFLAGS) -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 
-uname_p := $(shell uname -p)
+uname_m := $(shell uname -m)
 
-ifeq ($(uname_p),aarch64)
+ifeq ($(uname_m),aarch64)
     ARCH_CFLAGS = -DCONFIG_ARM -march=armv9-a
     PACA_FLAGS =-mbranch-protection=pac-ret+bti  -march=armv8.7-a
 endif


### PR DESCRIPTION
On certain Linux distributions (e.g., CentOS 10 VM on Arm64 MacOS), uname -p may return "unknown", but uname -m still returns "aarch64". Therefore, we should use uname -m for more reliability.